### PR TITLE
fix: improve auth form handling

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,27 +1,8 @@
 import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
-import { authService, User as ApiUser } from '../services/authService';
+import { authService } from '../services/authService';
 import { User } from '../types/user';
-
-interface User {
-  id: number;
-  email: string;
-  username: string;
-  full_name?: string;
-  avatar_url?: string;
-  role: string;
-  is_verified: boolean;
-  // Optional profile fields
-  bio?: string;
-  website?: string;
-  github_url?: string;
-  linkedin_url?: string;
-  // Optional seller stats
-  seller_rating?: number;
-  total_sales?: number;
-  total_earnings?: number;
-}
 
 interface AuthContextType {
   user: User | null;

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -11,13 +11,13 @@ export interface LoginResponse {
 
 class AuthService {
   async login(username: string, password: string): Promise<LoginResponse> {
-    const formData = new FormData();
-    formData.append('username', username);
-    formData.append('password', password);
+    const params = new URLSearchParams();
+    params.append('username', username);
+    params.append('password', password);
 
-    const response = await api.post<LoginResponse>('/auth/login', formData, {
+    const response = await api.post<LoginResponse>('/auth/login', params, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
     });
     return response.data;


### PR DESCRIPTION
## Summary
- fix login request formatting to use URL-encoded data
- clean up auth context to rely on shared user type

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6896393dfedc8327871c8c0929d0b447